### PR TITLE
fix: recover EOA signatures locally in /session verification

### DIFF
--- a/api/src/utils/auth_utils.ts
+++ b/api/src/utils/auth_utils.ts
@@ -1,5 +1,6 @@
 import { SiweMessage } from "siwe";
 import { createPublicClient, http } from 'viem';
+import { ethers } from 'ethers';
 
 const alchemyKey = process.env.ALCHEMY_API_KEY;
 
@@ -57,15 +58,30 @@ export async function verifySiweMessage(message: string, signature: string) {
     // console.log('Chain ID:', chainId);
     // console.log('Nonce:', nonce);
 
+    // Fast path: try local ECDSA recovery first. For standard EOA signatures
+    // this avoids any RPC call, so verification can't be broken by upstream
+    // RPC failures, rate limits, or missing API keys.
+    try {
+      const recovered = ethers.verifyMessage(message, signature);
+      if (recovered.toLowerCase() === address.toLowerCase()) {
+        return {
+          isValid: true,
+          address,
+          expirationTime,
+          nonce,
+        };
+      }
+    } catch {
+      // Not a standard 65-byte ECDSA signature (e.g. smart wallet) — fall
+      // through to the on-chain verification path below.
+    }
+
     // Use Alchemy or publicnode instead of WalletConnect RPC
     const rpcUrl = getRpcUrl(chainId);
-    // console.log('RPC URL:', rpcUrl);
 
     const publicClient = createPublicClient({
       transport: http(rpcUrl)
     });
-
-    // console.log('Calling publicClient.verifyMessage...');
 
     // Check if the address is a contract (smart wallet) by checking bytecode
     const bytecode = await publicClient.getBytecode({ address: address as `0x${string}` });


### PR DESCRIPTION
POST /session was returning 400 "Failed to verify message" for plain EOA sign-ins because the verification path always called viem's publicClient.getBytecode() + verifyMessage(), which depends on a reachable RPC. When ALCHEMY_API_KEY is unset the fallback public node was rate-limiting/timing out (observed ~1.4s wait before 400), causing verifySiweMessage to return isValid: false for perfectly valid ECDSA signatures.

Recover the signer locally with ethers.verifyMessage() first. If it matches the SIWE address, short-circuit — no RPC needed. Smart contract wallet paths still fall through to on-chain ERC-1271 / Reown signature checks.