### PR TITLE
fix: server identity uses personal claim name instead of AquaFire Server

### DIFF
--- a/api/src/utils/server_attest.ts
+++ b/api/src/utils/server_attest.ts
@@ -75,7 +75,7 @@ export async function serverAttestation(identityClaimId: string, walletAddress: 
             const genHash = getGenesisHash(aquaTree)
             if (genHash) {
                 const genRevision = aquaTree.revisions[genHash]
-                if (genRevision && genRevision["forms_type"] === "simple_claim") {
+                if (genRevision && genRevision["forms_type"] === "simple_claim" && genRevision["forms_claim_context"] === "Self issued server identity") {
                     serverIdentityAquaTree = aquaTree
                     serverIdentityFileObjects = fileObjects
                     break
@@ -259,35 +259,15 @@ export async function createServerIdentity() {
 
     const res = await prisma.revision.findFirst({
         where: {
-            AND: {
-                previous: {
-                    equals: ""
-                },
-                revision_type: {
-                    equals: "form"
-                },
-                pubkey_hash: {
-                    startsWith: walletAddress
-                }
-            },
-        },
-        select: {
-            AquaForms: {
-                where: {
-                    AND: {
-                        key: {
-                            equals: "forms_type"
-                        },
-                        value: {
-                            equals: "simple_claim"
-                        }
-                    }
-                }
-            }
+            previous: "",
+            revision_type: "form",
+            pubkey_hash: { startsWith: walletAddress },
+            AND: [
+                { AquaForms: { some: { key: "forms_type", value: { equals: "simple_claim" } } } },
+                { AquaForms: { some: { key: "forms_claim_context", value: { equals: "Self issued server identity" } } } }
+            ]
         }
     })
-
-    console.log("Res: ", res)
 
     if (res) {
         return


### PR DESCRIPTION
## Summary
- Fixed server attestations showing personal name ("kenn") instead of "AquaFire Server"
- Root cause: the `SERVER_MNEMONIC` wallet had pre-existing personal identity claims that blocked `createServerIdentity()` from creating the proper server identity
- `createServerIdentity()` now checks specifically for `claim_context = "Self issued server identity"` instead of any `simple_claim`
- `serverAttestation()` now only selects identity claims with the server-specific context, ignoring personal claims

## Test plan
- [ ] Verify dev.inblock.io CI/CD deploys successfully
- [ ] Check server attestations on dev show "AquaFire Server" instead of "kenn"
- [ ] Verify new server identity is created on restart (check DB for `claim_context = "Self issued server identity"`)
- [ ] Test email/phone attestation workflows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)