### PR TITLE
fix: aqua_sign workflow picks up personal identity instead of server …

### DIFF
--- a/api/src/controllers/explorer.ts
+++ b/api/src/controllers/explorer.ts
@@ -403,7 +403,7 @@ export default async function explorerController(fastify: FastifyInstance) {
                         const entryGenHash = getGenesisHash(entryAquaTree)
                         if (entryGenHash) {
                             const genRevision = entryAquaTree.revisions[entryGenHash]
-                            if (genRevision && genRevision["forms_type"] === "simple_claim") {
+                            if (genRevision && genRevision["forms_type"] === "simple_claim" && genRevision["forms_claim_context"] === "Self issued server identity") {
                                 serverIdentityAquaTree = entryAquaTree
                                 serverIdentityFileObjects = entryFileObjects
                                 break


### PR DESCRIPTION
…identity

The server identity lookup in the aqua_sign workflow (explorer.ts) only checked for forms_type "simple_claim", matching any user's identity claim on the server wallet. Now also requires forms_claim_context "Self issued server identity", consistent with the fix in server_attest.ts.

Closes #754